### PR TITLE
Add mapping_types in Symfony2 Doctrine Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Provides Doctrine Type classes for common postgres types
                 tsquery: "Doctrine\\DBAL\\PostgresTypes\\TsqueryType"
                 xml: "Doctrine\\DBAL\\PostgresTypes\\XmlType"
                 inet: "Doctrine\\DBAL\\PostgresTypes\\InetType"
+            mapping_types:
+                _text: text_array
+                _int4: int_array
+                tsvector: ts_vector
+                tsquery: ts_query
+                xml: xml
+                inet: inet
 
 #### Using with Doctrine
 


### PR DESCRIPTION
To avoid errors like 

`[Doctrine\DBAL\DBALException]                                                                            
Unknown database type _text requested, Doctrine\DBAL\Platforms\PostgreSQL92Platform may not support it.`

This can happen when executing `app/console doctrine:schema:update --force`.