### PR TITLE
Handle doctrine/orm v2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.2
+  - 7.3
+  - 7.4snapshot
 
 matrix:
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.2",
         "doctrine/dbal": "2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*|5.*"
+        "ext-simplexml": "*",
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Doctrine/DBAL/PostgresTypes/InetType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/InetType.php
@@ -52,4 +52,10 @@ class InetType extends Type
     {
         return 'inet';
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/IntArrayType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/IntArrayType.php
@@ -55,4 +55,10 @@ class IntArrayType extends Type
     {
         return '_int4';
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/MacAddrType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/MacAddrType.php
@@ -69,4 +69,10 @@ class MacAddrType extends Type
     {
         return 'macaddr';
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/TextArrayType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/TextArrayType.php
@@ -83,4 +83,10 @@ class TextArrayType extends Type
     {
         return 'TEXT[]';
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/TsqueryType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/TsqueryType.php
@@ -48,4 +48,10 @@ class TsqueryType extends Type
     {
         return sprintf('plainto_tsquery(%s)', $sqlExpr);
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/TsvectorType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/TsvectorType.php
@@ -110,4 +110,10 @@ class TsvectorType extends Type
 
         return $value;
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/DBAL/PostgresTypes/XmlType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/XmlType.php
@@ -99,4 +99,10 @@ class XmlType extends Type
 
         return $value;
     }
+
+    /** {@inheritdoc} */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/InetTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/InetTypeTest.php
@@ -9,14 +9,14 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Doctrine\DBAL\PostgresTypes\InetType;
 
-/**
- * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
- */
-class InetTypeTest extends \PHPUnit_Framework_TestCase
+final class InetTypeTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\InetType
+     * @var InetType
      */
     protected $_type;
 
@@ -25,29 +25,21 @@ class InetTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('inet', 'Doctrine\\DBAL\\PostgresTypes\\InetType');
+        Type::addType('inet', InetType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('inet');
     }
 
     /**
-     * Test conversion of PHP array to database value.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testInetConvertsToDatabaseValue($serialized, $phpValueToConvert)
+    public function testInetConvertsToDatabaseValue($serialized, $phpValueToConvert) : void
     {
         $converted = $this->_type->convertToDatabaseValue($phpValueToConvert, $this->_platform);
         $this->assertInternalType('string', $converted);
@@ -55,11 +47,9 @@ class InetTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test conversion of database value to PHP array.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testInetConvertsToPHPValue($serialized, $databaseValueToConvert)
+    public function testInetConvertsToPHPValue($serialized, $databaseValueToConvert) : void
     {
         $converted = $this->_type->convertToPHPValue($serialized, $this->_platform);
         $this->assertInternalType('string', $converted);
@@ -67,38 +57,30 @@ class InetTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     *
      * @dataProvider exceptionProvider
      */
-    public function testInetThrowExceptionOnConversion($value)
+    public function testInetThrowExceptionOnConversion($value) : void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->_type->convertToDatabaseValue($value, $this->_platform);
     }
 
-    /**
-     * Provider for conversion test values.
-     *
-     * @return array
-     */
-    public static function databaseConvertProvider()
+    public static function databaseConvertProvider() : array
     {
-        return array(
-            array('10.0.0.1', '10.0.0.1'),
-            array('10.0.0.1/4', '10.0.0.1/4'),
-        );
+        return [
+            ['10.0.0.1', '10.0.0.1'],
+            ['10.0.0.1/4', '10.0.0.1/4'],
+        ];
     }
 
-    /**
-     * @return array
-     */
-    public static function exceptionProvider()
+    public static function exceptionProvider() : array
     {
-        return array(
-            array(''),
-            array('someothervalue'),
-            array(123),
-            array('123345'),
-        );
+        return [
+            [''],
+            ['someothervalue'],
+            [123],
+            ['123345'],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/IntArrayTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/IntArrayTypeTest.php
@@ -7,18 +7,15 @@
  */
 namespace Doctrine\Tests\DBAL\Types;
 
+use Doctrine\DBAL\PostgresTypes\IntArrayType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use PHPUnit\Framework\TestCase;
 
-/**
- * Class IntArrayTypeTest.
- *
- * Unit tests for the IntArray type
- */
-class IntArrayTypeTest extends \PHPUnit_Framework_TestCase
+final class IntArrayTypeTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\IntArrayType
+     * @var IntArrayType
      */
     protected $_type;
 
@@ -27,29 +24,21 @@ class IntArrayTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('int_array', 'Doctrine\\DBAL\\PostgresTypes\\IntArrayType');
+        Type::addType('int_array', IntArrayType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('int_array');
     }
 
     /**
-     * Test conversion of PHP array to database value.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testIntArrayConvertsToDatabaseValue($serialized, $array)
+    public function testIntArrayConvertsToDatabaseValue($serialized, $array) : void
     {
         $converted = $this->_type->convertToDatabaseValue($array, $this->_platform);
         $this->assertInternalType('string', $converted);
@@ -57,11 +46,9 @@ class IntArrayTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test conversion of database value to PHP array.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testIntArrayConvertsToPHPValue($serialized, $array)
+    public function testIntArrayConvertsToPHPValue($serialized, $array) : void
     {
         $converted = $this->_type->convertToPHPValue($serialized, $this->_platform);
         $this->assertInternalType('array', $converted);
@@ -72,16 +59,11 @@ class IntArrayTypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * Provider for conversion test values.
-     *
-     * @return array
-     */
-    public static function databaseConvertProvider()
+    public static function databaseConvertProvider() : array
     {
-        return array(
-            array('{1,2,3}', array(1,2,3)),
-            array('{}', array()),
-        );
+        return [
+            ['{1,2,3}', [1, 2, 3]],
+            ['{}', []],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/MacAddrTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/MacAddrTypeTest.php
@@ -7,16 +7,17 @@
  */
 namespace Doctrine\Tests\DBAL\Types;
 
+use Doctrine\DBAL\PostgresTypes\InetType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Doctrine\DBAL\PostgresTypes\MacAddrType;
 
-/**
- * @author Evgeny Kukharik <jonegkk9@gmail.com>
- */
-class MacAddrTypeTest extends \PHPUnit_Framework_TestCase
+final class MacAddrTypeTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\InetType
+     * @var InetType
      */
     protected $_type;
 
@@ -25,29 +26,21 @@ class MacAddrTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('macaaddr', 'Doctrine\\DBAL\\PostgresTypes\\MacAddrType');
+        Type::addType('macaaddr', MacAddrType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('macaaddr');
     }
 
     /**
-     * Test conversion of PHP array to database value.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testMacAddrConvertsToDatabaseValue($serialized, $phpValueToConvert)
+    public function testMacAddrConvertsToDatabaseValue($serialized, $phpValueToConvert) : void
     {
         $converted = $this->_type->convertToDatabaseValue($phpValueToConvert, $this->_platform);
         $this->assertInternalType('string', $converted);
@@ -55,11 +48,9 @@ class MacAddrTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test conversion of database value to PHP array.
-     *
      * @dataProvider databaseConvertProvider
      */
-    public function testMacAddrConvertsToPHPValue($serialized, $databaseValueToConvert)
+    public function testMacAddrConvertsToPHPValue($serialized, $databaseValueToConvert) : void
     {
         $converted = $this->_type->convertToPHPValue($serialized, $this->_platform);
         $this->assertInternalType('string', $converted);
@@ -67,44 +58,36 @@ class MacAddrTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     *
      * @dataProvider exceptionProvider
      */
-    public function testMacAddrThrowExceptionOnConversion($value)
+    public function testMacAddrThrowExceptionOnConversion($value) : void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->_type->convertToDatabaseValue($value, $this->_platform);
     }
 
-    /**
-     * Provider for conversion test values.
-     *
-     * @return array
-     */
-    public static function databaseConvertProvider()
+    public static function databaseConvertProvider() : array
     {
-        return array(
-            array('08:00:2b:01:02:03', '08:00:2b:01:02:03'),
-            array('08-00-2b-01-02-03', '08-00-2b-01-02-03'),
-            array('08002b:010203', '08002b:010203'),
-            array('08002b-010203', '08002b-010203'),
-            array('0800.2b01.0203', '0800.2b01.0203'),
-            array('08002b010203', '08002b010203'),
-        );
+        return [
+            ['08:00:2b:01:02:03', '08:00:2b:01:02:03'],
+            ['08-00-2b-01-02-03', '08-00-2b-01-02-03'],
+            ['08002b:010203', '08002b:010203'],
+            ['08002b-010203', '08002b-010203'],
+            ['0800.2b01.0203', '0800.2b01.0203'],
+            ['08002b010203', '08002b010203'],
+        ];
     }
 
-    /**
-     * @return array
-     */
-    public static function exceptionProvider()
+    public static function exceptionProvider() : array
     {
-        return array(
-            array(''),
-            array('someothervalue'),
-            array(123),
-            array('123345'),
-            array('08-00-2b:01-02-03'),
-            array('08-00-2b:01-02-03-00')
-        );
+        return [
+            [''],
+            ['someothervalue'],
+            [123],
+            ['123345'],
+            ['08-00-2b:01-02-03'],
+            ['08-00-2b:01-02-03-00']
+        ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/TextArrayTypeTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/TextArrayTypeTest.php
@@ -7,17 +7,15 @@
  */
 namespace Doctrine\Tests\DBAL\Types;
 
+use Doctrine\DBAL\PostgresTypes\TextArrayType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
- * @author Eugene Leonovich <gen.work@gmail.com>
- */
-class TextArrayTypeTest extends \PHPUnit_Framework_TestCase
+final class TextArrayTypeTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\TextArrayType
+     * @var TextArrayType
      */
     protected $_type;
 
@@ -26,12 +24,12 @@ class TextArrayTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('text_array', 'Doctrine\\DBAL\\PostgresTypes\\TextArrayType');
+        Type::addType('text_array', TextArrayType::class);
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('text_array');
@@ -40,7 +38,7 @@ class TextArrayTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideValidValues
      */
-    public function testTextArrayConvertsToDatabaseValue($serialized, $array)
+    public function testTextArrayConvertsToDatabaseValue($serialized, $array) : void
     {
         $this->assertSame($serialized, $this->_type->convertToDatabaseValue($array, $this->_platform));
     }
@@ -48,39 +46,39 @@ class TextArrayTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideToPHPValidValues
      */
-    public function testTextArrayConvertsToPHPValue($serialized, $array)
+    public function testTextArrayConvertsToPHPValue($serialized, $array) : void
     {
         $this->assertSame($array, $this->_type->convertToPHPValue($serialized, $this->_platform));
     }
 
-    public static function provideValidValues()
+    public static function provideValidValues() : array
     {
-        return array(
-            array('{}', array()),
-            array('{""}', array('')),
-            array('{NULL}', array(null)),
-            array('{"1,NULL"}', array('1,NULL')),
-            array('{"NULL,2"}', array('NULL,2')),
-            array('{"1",NULL}', array('1', null)),
-            array('{"NULL"}', array('NULL')),
-            array('{"1,NULL"}', array('1,NULL')),
-            array('{"1","2"}', array('1', '2')),
-            array('{"1\"2"}', array('1"2')),
-            array('{"\"2"}', array('"2')),
-            array('{"\"\""}', array('""')),
-            array('{"1","2"}', array('1', '2')),
-            array('{"1,2","3,4"}', array('1,2', '3,4')),
-        );
+        return [
+            ['{}', []],
+            ['{""}', ['']],
+            ['{NULL}', [null]],
+            ['{"1,NULL"}', ['1,NULL']],
+            ['{"NULL,2"}', ['NULL,2']],
+            ['{"1",NULL}', ['1', null]],
+            ['{"NULL"}', ['NULL']],
+            ['{"1,NULL"}', ['1,NULL']],
+            ['{"1","2"}', ['1', '2']],
+            ['{"1\"2"}', ['1"2']],
+            ['{"\"2"}', ['"2']],
+            ['{"\"\""}', ['""']],
+            ['{"1","2"}', ['1', '2']],
+            ['{"1,2","3,4"}', ['1,2', '3,4']],
+        ];
     }
 
-    public static function provideToPHPValidValues()
+    public static function provideToPHPValidValues() : array
     {
-        return self::provideValidValues() + array(
-            array('{NULL,2}', array(null, '2')),
-            array('{NOTNULL}', array('NOTNULL')),
-            array('{NOTNULL,2}', array('NOTNULL', '2')),
-            array('{NULL2}', array('NULL2')),
-            array('{1,2}', array('1', '2')),
-        );
+        return self::provideValidValues() + [
+            ['{NULL,2}', [null, '2']],
+            ['{NOTNULL}', ['NOTNULL']],
+            ['{NOTNULL,2}', ['NOTNULL', '2']],
+            ['{NULL2}', ['NULL2']],
+            ['{1,2}', ['1', '2']],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/TsqueryTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/TsqueryTest.php
@@ -7,20 +7,15 @@
  */
 namespace Doctrine\Tests\DBAL\Types;
 
+use Doctrine\DBAL\PostgresTypes\TsqueryType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use PHPUnit\Framework\TestCase;
 
-/**
- * Doctrine\Tests\DBAL\Types\TsqueryTest.
- *
- * Unit tests for the Tsquery type
- *
- * @author Ivan Molchanov <ivan.molchanov@opensoftdev.ru>
- */
-class TsqueryTest extends \PHPUnit_Framework_TestCase
+final class TsqueryTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\TsqueryType
+     * @var TsqueryType
      */
     protected $type;
 
@@ -29,27 +24,18 @@ class TsqueryTest extends \PHPUnit_Framework_TestCase
      */
     protected $platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('tsquery', 'Doctrine\\DBAL\\PostgresTypes\\TsqueryType');
+        Type::addType('tsquery', TsqueryType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->platform = new PostgreSqlPlatform();
         $this->type = Type::getType('tsquery');
     }
 
-    /**
-     * Test conversion to database value.
-     */
-    public function testConvertToDatabaseValueSQL()
+    public function testConvertToDatabaseValueSQL() : void
     {
         $this->assertEquals('plainto_tsquery(test)', $this->type->convertToDatabaseValueSQL('test', $this->platform));
     }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/TsvectorTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/TsvectorTest.php
@@ -7,18 +7,15 @@
  */
 namespace Doctrine\Tests\DBAL\Types;
 
+use Doctrine\DBAL\PostgresTypes\TsvectorType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use PHPUnit\Framework\TestCase;
 
-/**
- * Class TsvectorTest.
- *
- * Unit tests for the TextArray type
- */
-class TsvectorTest extends \PHPUnit_Framework_TestCase
+final class TsvectorTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\TsvectorType
+     * @var TsvectorType
      */
     protected $_type;
 
@@ -27,35 +24,23 @@ class TsvectorTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('tsvector', 'Doctrine\\DBAL\\PostgresTypes\\TsvectorType');
+        Type::addType('tsvector', TsvectorType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('tsvector');
     }
 
-    /**
-     * Test conversion of PHP array to database value.
-     */
-    public function testTsvectorConvertsToDatabaseValue()
+    public function testTsvectorConvertsToDatabaseValue() : void
     {
         $this->assertInternalType('string', $this->_type->convertToDatabaseValue(array('simple', 'extended'), $this->_platform));
     }
 
-    /**
-     * Test conversion of database value to PHP array.
-     */
-    public function testTsvectorConvertsToPHPValue()
+    public function testTsvectorConvertsToPHPValue() : void
     {
         $this->assertInternalType('array', $this->_type->convertToPHPValue('ts:simple ts:extended', $this->_platform));
     }

--- a/tests/Doctrine/Tests/DBAL/PostgresTypes/XmlTest.php
+++ b/tests/Doctrine/Tests/DBAL/PostgresTypes/XmlTest.php
@@ -9,16 +9,14 @@ namespace Doctrine\Tests\DBAL\Types;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use PHPUnit\Framework\TestCase;
+use Doctrine\DBAL\PostgresTypes\XmlType;
+use SimpleXMLElement;
 
-/**
- * Class XmlTest.
- *
- * Unit tests for the XML type
- */
-class XmlTest extends \PHPUnit_Framework_TestCase
+final class XmlTest extends TestCase
 {
     /**
-     * @var \Doctrine\DBAL\PostgresTypes\XmlType
+     * @var XmlType
      */
     protected $_type;
 
@@ -27,36 +25,24 @@ class XmlTest extends \PHPUnit_Framework_TestCase
      */
     protected $_platform;
 
-    /**
-     * Pre-instantiation setup.
-     */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
-        Type::addType('xml', 'Doctrine\\DBAL\\PostgresTypes\\XmlType');
+        Type::addType('xml', XmlType::class);
     }
 
-    /**
-     * Pre-execution setup.
-     */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->_platform = new PostgreSqlPlatform();
         $this->_type = Type::getType('xml');
     }
 
-    /**
-     * Test conversion of SimpleXMLElement to database value.
-     */
-    public function testXmlConvertsToDatabaseValue()
+    public function testXmlConvertsToDatabaseValue() : void
     {
-        $this->assertInternalType('string', $this->_type->convertToDatabaseValue(new \SimpleXMLElement('<book></book>'), $this->_platform));
+        $this->assertInternalType('string', $this->_type->convertToDatabaseValue(new SimpleXMLElement('<book></book>'), $this->_platform));
     }
 
-    /**
-     * Test conversion of database value to SimpleXMLElement.
-     */
-    public function testXmlConvertsToPHPValue()
+    public function testXmlConvertsToPHPValue() : void
     {
-        $this->assertInstanceOf('\SimpleXMLElement', $this->_type->convertToPHPValue('<book></book>', $this->_platform));
+        $this->assertInstanceOf(SimpleXMLElement::class, $this->_type->convertToPHPValue('<book></book>', $this->_platform));
     }
 }


### PR DESCRIPTION
> The type "inet" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "Doctrine\DBAL\PostgresTypes\InetType::requiresSQLCommentHint()."