### PR TITLE
Issue 21: Return null on null entries for XmlType

### DIFF
--- a/src/Doctrine/DBAL/PostgresTypes/XmlType.php
+++ b/src/Doctrine/DBAL/PostgresTypes/XmlType.php
@@ -53,7 +53,7 @@ class XmlType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return $value === null ?: new \SimpleXMLElement($value);
+        return $value === null ? null : new \SimpleXMLElement($value);
     }
 
     /**


### PR DESCRIPTION
This PR solves [Issue 21](https://github.com/opensoft/doctrine-postgres-types/issues/21) for all PHP Versions.